### PR TITLE
feat: persist explored areas

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,14 +91,14 @@ Hooks.on('renderSceneControls', (controls) => {
 });
 
 function persistRevealedArea(token) {
-    if (game.user.isGM && canvas.worldExplorer?.settings.persistExploredAreas) {
-        // Computing token's center is required to not reveal an area to the token's left upon token's creation.
-        // This happened on "Hexagonal Rows - Odd" grid configuration during token creation. Using center works
-        // on every grid configuration afaik.
-        const center = {
-            x: token.data.x + ((token.parent?.dimensions?.size / 2) ?? 0),
-            y: token.data.y + ((token.parent?.dimensions?.size / 2) ?? 0),
-        };
-        canvas.worldExplorer?.reveal(center.x, center.y);
-    }
+    if (!game.user.isGM || !canvas.worldExplorer?.settings.persistExploredAreas) return;
+    
+    // Computing token's center is required to not reveal an area to the token's left upon token's creation.
+    // This happened on "Hexagonal Rows - Odd" grid configuration during token creation. Using center works
+    // on every grid configuration afaik.
+    const center = {
+        x: token.data.x + ((token.parent?.dimensions?.size / 2) ?? 0),
+        y: token.data.y + ((token.parent?.dimensions?.size / 2) ?? 0),
+    };
+    canvas.worldExplorer?.reveal(center.x, center.y);
 }

--- a/index.js
+++ b/index.js
@@ -34,13 +34,17 @@ Hooks.on("canvasReady", () => {
 });
 
 Hooks.on("createToken", (token) => {
-    if (token.object?.observer) canvas.worldExplorer?.refreshMask();
+    if (token.object?.observer) {
+        canvas.worldExplorer?.refreshMask();
+        persistRevealedArea(token);
+    }
 });
 
 Hooks.on("updateToken", (token, data) => {
     if (!token.object?.observer) return;
     if (data.x || data.y) {
         canvas.worldExplorer?.refreshMask();
+        persistRevealedArea(token);
     }
 });
 
@@ -85,3 +89,16 @@ Hooks.on('renderSceneControls', (controls) => {
     const isExplorer = controls.activeControl === "world-explorer";
     canvas.worldExplorer.editing = isExplorer && controls.activeTool === "toggle";
 });
+
+function persistRevealedArea(token) {
+    if (game.user.isGM && canvas.worldExplorer?.settings.persistExploredAreas) {
+        // Computing token's center is required to not reveal an area to the token's left upon token's creation.
+        // This happened on "Hexagonal Rows - Odd" grid configuration during token creation. Using center works
+        // on every grid configuration afaik.
+        const center = {
+            x: token.data.x + ((token.parent?.dimensions?.size / 2) ?? 0),
+            y: token.data.y + ((token.parent?.dimensions?.size / 2) ?? 0),
+        };
+        canvas.worldExplorer?.reveal(center.x, center.y);
+    }
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -10,7 +10,8 @@
             "Image": "Overlay Image",
             "Reveal": "Token Reveal (Distance)",
             "GM_Opacity": "Game Master Overlay Opacity",
-            "Player_Opacity": "Player Overlay Opacity"
+            "Player_Opacity": "Player Overlay Opacity",
+            "PersistExploredAreas": "Keep areas explored by tokens"
         },
         "Tools": {
             "Toggle": "Toggle Tiles"

--- a/lang/en.json
+++ b/lang/en.json
@@ -11,7 +11,7 @@
             "Reveal": "Token Reveal (Distance)",
             "GM_Opacity": "Game Master Overlay Opacity",
             "Player_Opacity": "Player Overlay Opacity",
-            "PersistExploredAreas": "Keep areas explored by tokens"
+            "Persist_Explored_Areas": "Keep areas explored by tokens"
         },
         "Tools": {
             "Toggle": "Toggle Tiles"

--- a/templates/scene-settings.html
+++ b/templates/scene-settings.html
@@ -43,3 +43,7 @@
         <span class="range-value">{{opacityPlayer}}</span>
     </div>
 </div>
+<div class="form-group">
+    <label>{{localize "WorldExplorer.SceneSettings.PersistExploredAreas"}}</label>
+    <input type="checkbox" name="flags.world-explorer.persistExploredAreas" {{checked persistExploredAreas}}/>
+</div>

--- a/templates/scene-settings.html
+++ b/templates/scene-settings.html
@@ -44,6 +44,6 @@
     </div>
 </div>
 <div class="form-group">
-    <label>{{localize "WorldExplorer.SceneSettings.PersistExploredAreas"}}</label>
+    <label>{{localize "WorldExplorer.SceneSettings.Persist_Explored_Areas"}}</label>
     <input type="checkbox" name="flags.world-explorer.persistExploredAreas" {{checked persistExploredAreas}}/>
 </div>

--- a/world-explorer-layer.mjs
+++ b/world-explorer-layer.mjs
@@ -178,8 +178,7 @@ export class WorldExplorerLayer extends CanvasLayer {
                 const x = token.center.x;
                 const y = token.center.y;
                 graphic.drawCircle(x, y, token.getLightRadius(radius));
-                if (persistExploredAreas === true)
-                {
+                if (persistExploredAreas === true) {
                     this.reveal(x, y);
                 }
             }

--- a/world-explorer-layer.mjs
+++ b/world-explorer-layer.mjs
@@ -172,15 +172,11 @@ export class WorldExplorerLayer extends CanvasLayer {
         // draw black over observer tokens
         const radius = Math.max(Number(this.scene.getFlag(MODULE, "revealRadius")) || 0, 0);
         if (radius > 0) {
-            const persistExploredAreas = game.user.isGM && this.scene.getFlag(MODULE, "persistExploredAreas");
             for (const token of canvas.tokens.placeables) {
                 if (!token.observer) continue;
                 const x = token.center.x;
                 const y = token.center.y;
                 graphic.drawCircle(x, y, token.getLightRadius(radius));
-                if (persistExploredAreas === true) {
-                    this.reveal(x, y);
-                }
             }
         }
 

--- a/world-explorer-layer.mjs
+++ b/world-explorer-layer.mjs
@@ -5,6 +5,7 @@ export const DEFAULT_SETTINGS = {
     revealRadius: 0,
     opacityGM: 0.7,
     opacityPlayer: 1,
+    persistExploredAreas: false,
 };
 
 export class WorldExplorerLayer extends CanvasLayer {
@@ -171,11 +172,16 @@ export class WorldExplorerLayer extends CanvasLayer {
         // draw black over observer tokens
         const radius = Math.max(Number(this.scene.getFlag(MODULE, "revealRadius")) || 0, 0);
         if (radius > 0) {
+            const persistExploredAreas = game.user.isGM && this.scene.getFlag(MODULE, "persistExploredAreas");
             for (const token of canvas.tokens.placeables) {
                 if (!token.observer) continue;
                 const x = token.center.x;
                 const y = token.center.y;
                 graphic.drawCircle(x, y, token.getLightRadius(radius));
+                if (persistExploredAreas === true)
+                {
+                    this.reveal(x, y);
+                }
             }
         }
 


### PR DESCRIPTION
Hi,

Thanks for this great addon, I discovered the late image fog recently and was worried no replacement existed... I discovered your module yesterday while browsing foundry's list as googling led me nowhere.

I made a small change to keep persisted areas as described in https://github.com/CarlosFdez/world-explorer/issues/6 as it's a feature I also desired. By default, it's disabled to respect your intention regarding pf2e's feat.

Let me know if any changes are required to this PR and thanks again :)