### PR TITLE
Add support for foundry 11

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "world-explorer",
   "title": "World Explorer",
   "description": "Manual reveal of background image for map traversal tracking",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "authors": [
     {
       "name": "Supe"
@@ -10,7 +10,8 @@
   ],
   "compatibility": {
     "minimum": "10",
-    "verified": "10.283"
+    "verified": "11",
+    "maximum": "11"
   },
   "esmodules": [
     "index.js"
@@ -32,5 +33,5 @@
   ],
   "url": "https://github.com/CarlosFdez/world-explorer",
   "manifest": "https://github.com/CarlosFdez/world-explorer/releases/latest/download/module.json",
-  "download": "https://github.com/CarlosFdez/world-explorer/releases/download/v0.7.2/module.zip"
+  "download": "https://github.com/CarlosFdez/world-explorer/releases/download/v0.8.0/module.zip"
 }


### PR DESCRIPTION
Made some minor changes to the way that children are being added to the layer:
- Removed wrapping `this.overlay`
- `overlayBackground` and `fogSprite` and `maskSprite` are added directly to the layer

The mask texture is updated directly instead of modifying the texture the Sprite is based on. I _believe_ the change from PIXI v6 (Foundry 10) to v7 (Foundry 11) changed the behavior of this texture handling.

The same graphics generation logic is still in place, but the way the texture is generated has been changed.

----

I'm not sure they way you want to handle versioning and updating of version tag. I pre-emptively made the change, but I'm not sure the proper procedure when it comes to that.