### PR TITLE
Partly reveal spaces with their own color (#14)

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ Hooks.on("init", async () => {
         group: "primary",
     };
 
+    const { SceneConfig } = foundry.applications.sheets;
     // Add the world explorer tab and config to the scene config
     // We need to make sure the world explorer tab renders before the footer
     const label = game.i18n.localize("WorldExplorer.Name");
@@ -50,7 +51,7 @@ Hooks.on("canvasReady", () => {
 Hooks.on("createToken", (token) => {
     updateForToken(token);
     if (canvas.worldExplorer?.settings.revealRadius) {
-        canvas.worldExplorer.refreshMask();
+        canvas.worldExplorer.refreshMasks();
     }
 });
 
@@ -70,7 +71,7 @@ Hooks.on("refreshToken", (token, options) => {
 
 Hooks.on("deleteToken", () => {
     if (canvas.worldExplorer?.settings.revealRadius) {
-        canvas.worldExplorer.refreshMask();
+        canvas.worldExplorer.refreshMasks();
     }
 });
 
@@ -240,6 +241,6 @@ function updateForToken(token, data={}) {
 
 const refreshThrottled = foundry.utils.throttle(() => {
     if (canvas.worldExplorer?.settings.revealRadius) {
-        canvas.worldExplorer.refreshMask();
+        canvas.worldExplorer.refreshMasks();
     }
 }, 30);

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ Hooks.on("getSceneControlButtons", (controls) => {
     controls.worldExplorer = {
         name: "worldExplorer",
         title: game.i18n.localize("WorldExplorer.Name"),
-        icon: "fa-solid fa-map",
+        icon: "fa-solid fa-globe",
         layer: "worldExplorer",
         onChange: (_event, active) => {
             if (active) canvas.worldExplorer.activate();
@@ -188,7 +188,7 @@ Hooks.on("getSceneControlButtons", (controls) => {
                             },
                             {
                                 action: "partial",
-                                icon: "fa-solid fa-cloud-fog",
+                                icon: "fa-duotone fa-cloud",
                                 label: game.i18n.localize("WorldExplorer.ResetDialog.Choices.Partial"),
                                 callback: () => canvas.worldExplorer.clear({ partial: true }),
                             },

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,23 +1,35 @@
 {
     "WorldExplorer": {
         "Name": "World Explorer",
-        "Settings": {
-        },
         "SceneSettings": {
-            "Description": "Configure settings for the World Explorer module",
-            "Enabled": "Enable the module to work for this scene",
-            "Color": "Overlay Color",
-            "Image": "Overlay Image",
-            "Reveal": "Token Reveal (Distance)",
+            "Enabled": "Enable for this scene",
+            "Image": {
+                "Label": "Overlay Image"
+            },
+            "Colors": {
+                "Overlay": {
+                    "Label": "Overlay Color",
+                    "Hint": "When using an overlay image, this overlay color is ignored."
+                },
+                "Partial": {
+                    "Label": "Partly Revealed Color",
+                    "Hint": "Leave empty to use the overlay color above, and no color when using an overlay image. If filled, this is used to color partly revealed spaces of an overlay image for the GM only."
+                }
+            },
+            "Opacity": {
+                "Title": "{role} Overlay Opacity",
+                "Hidden": "Hidden Spaces",
+                "Partial": "Partly Revealed Spaces"
+            },
             "GridReveal": {
-                "Name": "Grid Extended Reveal (Distance)",
-                "Hint": "Extends visibility of revealed grid spaces into adjacent spaces."
+                "Label": "Extended Revealed Spaces",
+                "Hint": "The revealed grid spaces extend a certain amount into hidden and partly revealed spaces. Does not extend the partly revealed spaces."
             },
             "GM_Opacity": "GM Overlay Opacity",
             "Player_Opacity": "Player Overlay Opacity",
             "Persist_Explored_Areas": "Keep areas explored by tokens",
             "Position": {
-                "Name": "Overlay Position",
+                "Label": "Overlay Position",
                 "Hint": "Whether it should display below tiles and textures or above.",
                 "Choices": {
                     "back": "Cover the map only",
@@ -25,21 +37,32 @@
                     "behindTokens": "Cover the map, non-overhead tiles, and drawings",
                     "front": "Cover everything except grid"
                 }
+            },
+            "TokenInteractions" : {
+                "Title": "Token Interactions",
+                "TokenReveal": "Token Reveal Distance",
+                "PersistExplored": "Keep areas explored by tokens"
             }
         },
         "Tools": {
             "Toggle": "Toggle Spaces",
             "Reveal": "Reveal Spaces",
+            "Partial": "Partly Reveal Spaces",
             "Hide": "Hide Spaces",
-            "Opacity": "GM Overlay Opacity",
-            "Reset": "Reset Scene"
+            "Reset": "Reset Scene",
+            "Opacity": {
+                "Title" : "GM Overlay Opacities",
+                "Partial": "GM Partly Revealed Opacity",
+                "Hidden": "GM Hidden Opacity"
+            }
         },
         "ResetDialog": {
             "Title": "Reset Scene?",
-            "Content": "Are you sure you want to reset and update the entire scene?",
-            "Confirm": "Type this exact code in the box below in order to proceed: <strong>{code}</strong>",
+            "Content": "Are you sure you want to reset and update the entire scene?</br>This can't be undone!",
+            "Confirm": "Enter this exact code in the box below to proceed: <strong>{code}</strong>",
             "Choices": {
                 "Explored": "Show All",
+                "Partial": "Partial All",
                 "Unexplored": "Hide All"
             }
         },

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1,17 +1,23 @@
 {
     "WorldExplorer": {
         "Name": "ワールドマスク",
-        "Settings": {
-        },
         "SceneSettings": {
-            "Description": "ワールドマスクの設定",
             "Enabled": "このシーンでModを使用する",
-            "Color": "マスク色",
-            "Image": "マスク画像",
-            "Reveal": "コマ視認距離",
-            "GM_Opacity": "GMのマスクの不透明度",
-            "Player_Opacity": "PLのマスクの不透明度",
-            "Persist_Explored_Areas": "コマが見たマスクを記憶する"
+            "Image": {
+                "Label": "マスク画像"
+            },
+            "Colors": {
+                "Overlay": {
+                    "Label": "マスク色"
+                }
+            },
+            "Opacity": {
+                "Title": "{role}のマスクの不透明度"
+            },
+            "TokenInteractions" : {
+                "TokenReveal": "コマ視認距離",
+                "PersistExplored": "コマが見たマスクを記憶する"
+            }
         },
         "Tools": {
             "Toggle": "タイル切替",

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "world-explorer",
   "title": "World Explorer",
   "description": "Manual reveal of background image for map traversal tracking",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "authors": [
     {
       "name": "Supe",

--- a/module.json
+++ b/module.json
@@ -32,7 +32,7 @@
     }
   ],
   "styles": [
-    "styles/style.css"
+    "styles/world-explorer.css"
   ],
   "url": "https://github.com/CarlosFdez/world-explorer",
   "manifest": "https://github.com/CarlosFdez/world-explorer/releases/latest/download/module.json",

--- a/module/opacity-slider.mjs
+++ b/module/opacity-slider.mjs
@@ -1,3 +1,4 @@
+import { DEFAULT_SETTINGS } from "./world-explorer-layer.mjs";
 const fapi = foundry.applications.api;
 
 export class OpacityGMAdjuster extends fapi.HandlebarsApplicationMixin(fapi.Application) {
@@ -16,7 +17,7 @@ export class OpacityGMAdjuster extends fapi.HandlebarsApplicationMixin(fapi.Appl
         },
         position: {
             width: 400,
-            height: 38,
+            height: 80,
         }
     }
 
@@ -33,6 +34,7 @@ export class OpacityGMAdjuster extends fapi.HandlebarsApplicationMixin(fapi.Appl
         const flags = this.scene.flags["world-explorer"] ?? {};
         return {
             opacityGM: flags.opacityGM ?? DEFAULT_SETTINGS.opacityGM,
+            partialOpacityGM: flags.partialOpacityGM ?? DEFAULT_SETTINGS.partialOpacityGM,
         };
     }
 
@@ -55,16 +57,16 @@ export class OpacityGMAdjuster extends fapi.HandlebarsApplicationMixin(fapi.Appl
             element.style.top = `${bounds.top}px`;
         }
 
-        const slider = element.querySelector("[type=range]");
-        slider?.addEventListener("input", (event) => {
+        element.addEventListener("input", (event) => {
             const value = Number(event.target.value);
-            this.scene.update({ "flags.world-explorer.opacityGM": value });
+            const updateId = event.target.parentNode.name;
+            this.scene.update({ [updateId]: value });
         });
     }
 
-    detectClose(controls) {
-        if (controls.control.name !== "worldExplorer" && this.rendered) {
-            $("#world-explorer-opacity-adjuster").fadeOut(() => {
+    detectClose(controls = {}) {
+        if (controls.control?.name !== "worldExplorer" && this.rendered) {
+            $(`#${this.id}`).fadeOut(() => {
                 this.close({ force: true });
             });
         }
@@ -72,12 +74,10 @@ export class OpacityGMAdjuster extends fapi.HandlebarsApplicationMixin(fapi.Appl
 
     toggleVisibility() {
         if (this.rendered) {
-            $("#world-explorer-opacity-adjuster").fadeOut(() => {
-                this.close({ force: true });
-            });
+            this.detectClose();
         } else {
             this.render({ force: true, scene: canvas.scene }).then(() => {
-                $("#world-explorer-opacity-adjuster").hide().fadeIn();
+                $(`#${this.id}`).hide().fadeIn({duration: 250});
             });
         }
     }

--- a/module/util.mjs
+++ b/module/util.mjs
@@ -72,6 +72,6 @@ export function uniqBy(arr, fn) {
     }, []);
 }
 
-export function uniq(arr) {
-    return uniqBy(arr, String);
+export function uniqPosition(arr) {
+    return uniqBy(arr, (p) => String(p.slice(0,-1)));
 }

--- a/module/util.mjs
+++ b/module/util.mjs
@@ -1,8 +1,8 @@
 /**
- * 
- * @param {unknown} object 
- * @param {{ before?: string, after?: string, key: string, value: unknown }} options 
- * @returns 
+ *
+ * @param {unknown} object
+ * @param {{ before?: string, after?: string, key: string, value: unknown }} options
+ * @returns
  */
 export function insertIntoObject(object, options) {
     const result = {};

--- a/module/world-explorer-layer.mjs
+++ b/module/world-explorer-layer.mjs
@@ -142,7 +142,7 @@ export class WorldExplorerLayer extends foundry.canvas.layers.InteractionLayer {
         this.addChild(this.hiddenTiles);
         this.addChild(this.hiddenTiles.mask);
 
-        // Graphic to cover the partially revealed tiles (doesn't need an image texture, so use sprite)
+        // Graphic to cover the partially revealed tiles (doesn't need an image texture, so use Graphics)
         // Needs to be separate, for we want it to have a different color
         this.partialTiles = new PIXI.Graphics();
         // Create a separate mask for it, as it will also have separate transparency so it can overlay the image texture
@@ -558,9 +558,15 @@ export class WorldExplorerLayer extends foundry.canvas.layers.InteractionLayer {
      */
     _getPlainTexture() {
         const { sceneRect } = canvas.dimensions;
+        // Taken from SimpleFog - a way to deal with high resolution scenes and not run out of memory
+        let res = 1.0;
+        if (sceneRect.width * sceneRect.height > 16000 ** 2) res = 0.25;
+        else if (sceneRect.width * sceneRect.height > 8000 ** 2) res = 0.5;
+
         return PIXI.RenderTexture.create({
             width: sceneRect.width,
             height: sceneRect.height,
+            resolution: res,
         });
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,63 +1,578 @@
 {
   "name": "world-explorer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "world-explorer",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "devDependencies": {
-        "pixi.js": "^7.2.4",
+        "pixi.js": "^7.4.3",
         "prompts": "^2.4.2",
         "typescript": "^4.7.4"
       }
     },
-    "node_modules/@pixi/color": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.2.4.tgz",
-      "integrity": "sha512-B/+9JRcXe2uE8wQfsueFRPZVayF2VEMRB7XGeRAsWCryOX19nmWhv0Nt3nOU2rvzI0niz9XgugJXsB6vVmDFSg==",
+    "node_modules/@pixi/accessibility": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.4.3.tgz",
+      "integrity": "sha512-tCr0yeWpMe0yucFvEPidy5a7gVJGpTjqGrDpSEBYT/kbScfUwcoX49RrckCCCiXDlyO4WRh9lVVuHXTvqRLIMg==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/events": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/app": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.4.3.tgz",
+      "integrity": "sha512-opyWMuO0Ir8pf1DYUR++wAA6ZfNU+nIX2z95R2OD172HbcdhB4/HD7leLIIAny/LciEdMqlWEBhXK7N93YWbdg==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/assets": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.3.tgz",
+      "integrity": "sha512-StvjiJBSp/j9hHkGu8AFHNvwYUazXq64WhyhytztyDMRkg/l/cL7EcttY5T0qZNWlIpccdr60LUKrWDOuMpkiw==",
       "dev": true,
       "dependencies": {
-        "colord": "^2.9.3"
+        "@types/css-font-loading-module": "^0.0.12"
+      },
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/color": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.4.3.tgz",
+      "integrity": "sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==",
+      "dev": true,
+      "dependencies": {
+        "@pixi/colord": "^2.9.6"
+      }
+    },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "dev": true
+    },
+    "node_modules/@pixi/compressed-textures": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.4.3.tgz",
+      "integrity": "sha512-uJ3CC+lNX4HIxs6IxEESO50/0A1KxSVm6CO9UlkXzTsNj9ynmdy5BkJ1dzii7LCdqGcHIXHO01yvKuUbJBBQtw==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/assets": "7.4.3",
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/constants": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.3.tgz",
+      "integrity": "sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==",
+      "dev": true
+    },
+    "node_modules/@pixi/core": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.3.tgz",
+      "integrity": "sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==",
+      "dev": true,
+      "dependencies": {
+        "@pixi/color": "7.4.3",
+        "@pixi/constants": "7.4.3",
+        "@pixi/extensions": "7.4.3",
+        "@pixi/math": "7.4.3",
+        "@pixi/runner": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@pixi/ticker": "7.4.3",
+        "@pixi/utils": "7.4.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/@pixi/display": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.3.tgz",
+      "integrity": "sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/events": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.3.tgz",
+      "integrity": "sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
       }
     },
     "node_modules/@pixi/extensions": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.2.4.tgz",
-      "integrity": "sha512-Mnqv9scbL1ARD3QFKfOWs2aSVJJfP1dL8g5UiqGImYO3rZbz/9QCzXOeMVIZ5n3iaRyKMNhFFr84/zUja2H7Dw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.3.tgz",
+      "integrity": "sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw==",
       "dev": true
     },
+    "node_modules/@pixi/extract": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.4.3.tgz",
+      "integrity": "sha512-HNvGNrEVaeVsbcnIO1MsHpjZbTwo9nIlaOEBzDGcL6JWwzuB1RnzUke7WUCndCUt91sGUdvPnvgCvy9/NNFg3w==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-alpha": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.4.3.tgz",
+      "integrity": "sha512-YFdUB1I53USQb+9TEhS849dV2KZhbnNGIoBbOSThUJfXQc4pDguIFWMagVToAQYgmZ4C4AtYfVjaSEELrMcCdA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-blur": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.4.3.tgz",
+      "integrity": "sha512-ZFzS9L/whdRbs5A/EUgF3yQaBcxNarmbuwaMgrfnpQ84mRczkGByqDLGToadiufyals07ufTrXBGRle9lbtEDA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-color-matrix": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.4.3.tgz",
+      "integrity": "sha512-TNu0h20SrzjUWIb5v19dAp1vPpqtG0w2XF9kIHN91bMNaf3R1jzhpWG6TtaVO9eo1IolWcEJLw38jIohyC+KNw==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-displacement": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.4.3.tgz",
+      "integrity": "sha512-ax+cFA2mEnKgqf9F8qInpv09GNWzjwnASLETpwPXzWBtlAlNCeHV2tCv3+SlMdEKUkwG9sA7AmjjjC2JBUyt+Q==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-fxaa": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.4.3.tgz",
+      "integrity": "sha512-y9jhho5cCflhEsPtNqqsd+XJHsb+/ysht4rG/VHQ8Z6pScHYpbgiEpowryGq8uSMQQwx6zKNS2DPiXdiOHPZsg==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-noise": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.4.3.tgz",
+      "integrity": "sha512-rwgSO3BKe1jW/P5CaOcfLKjfpl674aBEo/igi/3QLxA3ORhILNqWRsKkOwP8xF/ejI5NE4rMEkdv0LScbdGFhA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/graphics": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.3.tgz",
+      "integrity": "sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/math": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.3.tgz",
+      "integrity": "sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw==",
+      "dev": true
+    },
+    "node_modules/@pixi/mesh": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.3.tgz",
+      "integrity": "sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mesh-extras": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.4.3.tgz",
+      "integrity": "sha512-EqpxpVZoTObyupxMSzuUsCGmWPQioW84n9EO9Ajawkk/HYA+qKFZ5viKiEThIUBYgv4Apn/7c0U3Feg7Ez4uQQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/mesh": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mixin-cache-as-bitmap": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.4.3.tgz",
+      "integrity": "sha512-NgvDdgSgd2tfcTSc+SWF12JJjVVz5ZrkSlhX0idSp/LSako82AiFJlD2xqH9GUsEcA6sqBBlnu7nrGkPTHQdhA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mixin-get-child-by-name": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.4.3.tgz",
+      "integrity": "sha512-HLhDxHwafQT+CxbqQx9w9ivJIyAOg9JJ/6m4fNymVuDWeuMGcxDxBD7DukdUYIieT+RD/RlxdPEmq8YoromlFA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mixin-get-global-position": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.4.3.tgz",
+      "integrity": "sha512-k09kvkS379EypCIWgXMY7uiXtWk1BsaJyTYlV16Co0AsmNPdFd+wUozMx1xV6rxcGiWXsxr/1k9fbETuYkcXCQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/particle-container": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.4.3.tgz",
+      "integrity": "sha512-0DfJF5C0XTfuI2FsLYvMKCOtqWjXWGOWfA6m4l0W/Ke/qw5zKIOEhgjPLw4qNRtOhmEfkVKJUGp66Ap/ya2YzA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/prepare": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.4.3.tgz",
+      "integrity": "sha512-OjJHGKXPzwP5OLKxBnTBnKMOktHynLvO0TQPqTYgNtmGQzY109mypCqM4M+s/V+uYmBo/T+sXvBahj98q/f1tA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/graphics": "7.4.3",
+        "@pixi/text": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/runner": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.3.tgz",
+      "integrity": "sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw==",
+      "dev": true
+    },
+    "node_modules/@pixi/settings": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.4.3.tgz",
+      "integrity": "sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==",
+      "dev": true,
+      "dependencies": {
+        "@pixi/constants": "7.4.3",
+        "@types/css-font-loading-module": "^0.0.12",
+        "ismobilejs": "^1.1.0"
+      }
+    },
+    "node_modules/@pixi/sprite": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.3.tgz",
+      "integrity": "sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/sprite-animated": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.4.3.tgz",
+      "integrity": "sha512-mw5YIec8KfO1Jv9qrDNvGoD7Dlmcgww5YlMtd+ARi7Zzo+6ziNw899LXtoaKX1+3BXdZbYNyJAx3C5r30NtwXA==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/sprite-tiling": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.4.3.tgz",
+      "integrity": "sha512-kUa9cEcMsGXSIZoXA7LhW4oo0eWa30w0KYd7mZ0bqalBMfOcvsGZMN701Lc5lpE8URw+8yu5bnyGLbrxhWBTuw==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/spritesheet": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.4.3.tgz",
+      "integrity": "sha512-Ce4xZzUxUSKfiROUjjVCBYNLuCcDEWKJ822bSV9rkgVHItu3q04VnEww0DXO+9K0hKv4Ukjjk8aP6Pz0LgPm7A==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/assets": "7.4.3",
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/text": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.3.tgz",
+      "integrity": "sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/text-bitmap": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.4.3.tgz",
+      "integrity": "sha512-TnBocJm7f5nMAYwYcsojc62uCrOYauAGH26o3pNrlqmHDRDQ7FzPOGvkYZGYFREbUycloLSRlYpSy0FB9ZdV4Q==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/assets": "7.4.3",
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/mesh": "7.4.3",
+        "@pixi/text": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/text-html": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.4.3.tgz",
+      "integrity": "sha512-nm9K9gjSZAU8ETwQZBE3kMGNdO1IzyghxoRTcJCWKhekiGDpUQhopfNhqieNZ7reVJpvhpFQWjbyaHDehndUaQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3",
+        "@pixi/text": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/ticker": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.3.tgz",
+      "integrity": "sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==",
+      "dev": true,
+      "dependencies": {
+        "@pixi/extensions": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@pixi/utils": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/utils": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.3.tgz",
+      "integrity": "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==",
+      "dev": true,
+      "dependencies": {
+        "@pixi/color": "7.4.3",
+        "@pixi/constants": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^4.0.0",
+        "url": "^0.11.0"
+      }
+    },
     "node_modules/@types/css-font-loading-module": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
+      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
       "dev": true
     },
     "node_modules/@types/earcut": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
-      "integrity": "sha512-w8oigUCDjElRHRRrMvn/spybSMyX8MTkKA5Dv+tS1IE/TgmNZPqUYtvYBXGY8cieSE66gm+szeK+bnbxC2xHTQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
+      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
       "dev": true
     },
-    "node_modules/@types/offscreencanvas": {
-      "version": "2019.7.0",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
-      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==",
-      "dev": true
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
-    "node_modules/colord": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-      "dev": true
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/earcut": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
       "dev": true
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/ismobilejs": {
       "version": "1.1.1",
@@ -75,415 +590,68 @@
         "node": ">=6"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/pixi.js": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.2.4.tgz",
-      "integrity": "sha512-nBH60meoLnHxoMFz17HoMxXS4uJpG5jwIdL+Gx2S11TzWgP3iKF+/WLOTrkSdyuQoQSdIBxVqpnYii0Wiox15A==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.4.3.tgz",
+      "integrity": "sha512-uIWdH0EI2dVgNoqN9aFaHCmR0V65OEhMkXs2sek3c/QP2ItV6UoM+ouX9esSv3ibo20F+J5D1XwnQhUZI6wqeQ==",
       "dev": true,
       "dependencies": {
-        "@pixi/accessibility": "7.2.4",
-        "@pixi/app": "7.2.4",
-        "@pixi/assets": "7.2.4",
-        "@pixi/compressed-textures": "7.2.4",
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4",
-        "@pixi/events": "7.2.4",
-        "@pixi/extensions": "7.2.4",
-        "@pixi/extract": "7.2.4",
-        "@pixi/filter-alpha": "7.2.4",
-        "@pixi/filter-blur": "7.2.4",
-        "@pixi/filter-color-matrix": "7.2.4",
-        "@pixi/filter-displacement": "7.2.4",
-        "@pixi/filter-fxaa": "7.2.4",
-        "@pixi/filter-noise": "7.2.4",
-        "@pixi/graphics": "7.2.4",
-        "@pixi/mesh": "7.2.4",
-        "@pixi/mesh-extras": "7.2.4",
-        "@pixi/mixin-cache-as-bitmap": "7.2.4",
-        "@pixi/mixin-get-child-by-name": "7.2.4",
-        "@pixi/mixin-get-global-position": "7.2.4",
-        "@pixi/particle-container": "7.2.4",
-        "@pixi/prepare": "7.2.4",
-        "@pixi/sprite": "7.2.4",
-        "@pixi/sprite-animated": "7.2.4",
-        "@pixi/sprite-tiling": "7.2.4",
-        "@pixi/spritesheet": "7.2.4",
-        "@pixi/text": "7.2.4",
-        "@pixi/text-bitmap": "7.2.4",
-        "@pixi/text-html": "7.2.4"
+        "@pixi/accessibility": "7.4.3",
+        "@pixi/app": "7.4.3",
+        "@pixi/assets": "7.4.3",
+        "@pixi/compressed-textures": "7.4.3",
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/events": "7.4.3",
+        "@pixi/extensions": "7.4.3",
+        "@pixi/extract": "7.4.3",
+        "@pixi/filter-alpha": "7.4.3",
+        "@pixi/filter-blur": "7.4.3",
+        "@pixi/filter-color-matrix": "7.4.3",
+        "@pixi/filter-displacement": "7.4.3",
+        "@pixi/filter-fxaa": "7.4.3",
+        "@pixi/filter-noise": "7.4.3",
+        "@pixi/graphics": "7.4.3",
+        "@pixi/mesh": "7.4.3",
+        "@pixi/mesh-extras": "7.4.3",
+        "@pixi/mixin-cache-as-bitmap": "7.4.3",
+        "@pixi/mixin-get-child-by-name": "7.4.3",
+        "@pixi/mixin-get-global-position": "7.4.3",
+        "@pixi/particle-container": "7.4.3",
+        "@pixi/prepare": "7.4.3",
+        "@pixi/sprite": "7.4.3",
+        "@pixi/sprite-animated": "7.4.3",
+        "@pixi/sprite-tiling": "7.4.3",
+        "@pixi/spritesheet": "7.4.3",
+        "@pixi/text": "7.4.3",
+        "@pixi/text-bitmap": "7.4.3",
+        "@pixi/text-html": "7.4.3"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
       }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/accessibility": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.2.4.tgz",
-      "integrity": "sha512-EVjuqUqv9FeYFXCv0S0qj1hgCtbAMNBPCbOGEtiMogpM++/IySxBZvcOYg3rRgo9inwt2s4Bi7kUiqMPD8hItw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4",
-        "@pixi/events": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/app": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.2.4.tgz",
-      "integrity": "sha512-eJ2jpu5P28ip07nLItw6sETXn45P4KR/leMJ6zPHRlhT1m8t5zTsWr3jK4Uj8LF2E+6KlPNzLQh5Alf/unn/aQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/assets": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.2.4.tgz",
-      "integrity": "sha512-7199re3wvMAlVqXLaCyAr8IkJSXqkeVAxcYyB2rBu4Id5m2hhlGX1dQsdMBiCXLwu6/LLVqDvJggSNVQBzL6ZQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/css-font-loading-module": "^0.0.7"
-      },
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/utils": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/compressed-textures": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.2.4.tgz",
-      "integrity": "sha512-atnWyw/ot/Wg69qhgskKiuTYCZx15IxV35sa0KyXMthyjyvDLCIvOn0nczM6wCBy9H96SjJbfgynVWhVrip6qw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/assets": "7.2.4",
-        "@pixi/core": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/constants": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.2.4.tgz",
-      "integrity": "sha512-hKuHBWR6N4Q0Sf5MGF3/9l+POg/G5rqhueHfzofiuelnKg7aBs3BVjjZ+6hZbd6M++vOUmxYelEX/NEFBxrheA==",
-      "dev": true
-    },
-    "node_modules/pixi.js/node_modules/@pixi/core": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.2.4.tgz",
-      "integrity": "sha512-0XtvrfxHlS2T+beBBSpo7GI8+QLyyTqMVQpNmPqB4woYxzrOEJ9JaUFBaBfCvycLeUkfVih1u6HAbtF+2d1EjQ==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/color": "7.2.4",
-        "@pixi/constants": "7.2.4",
-        "@pixi/extensions": "7.2.4",
-        "@pixi/math": "7.2.4",
-        "@pixi/runner": "7.2.4",
-        "@pixi/settings": "7.2.4",
-        "@pixi/ticker": "7.2.4",
-        "@pixi/utils": "7.2.4",
-        "@types/offscreencanvas": "^2019.6.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/display": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.2.4.tgz",
-      "integrity": "sha512-w5tqb8cWEO5qIDaO9GEqRvxYhL0iMk0Wsngw23bbLm1gLEQmrFkB2tpJlRAqd7H82C3DrDDeWvkrrxW6+m4apg==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/events": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.2.4.tgz",
-      "integrity": "sha512-/JtmoB98fzIU8giN9xvlRvmvOi6u4MaD2DnKNOMHkQ1MBraj3pmrXM9fZ0JbNzi+324GraAAY76QidgHjIYoYQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/extract": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.2.4.tgz",
-      "integrity": "sha512-wlXZg+J2L/1jQhRi5nZQP/cXshovhjksjss91eAKMvY5aGxNAQovCP4xotJ/XJjfTvPMpeRzHPFYzm3PrOPQ7g==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-alpha": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.2.4.tgz",
-      "integrity": "sha512-UTUMSGyktUr+I9vmigqJo9iUhb0nwGyqTTME2xBWZvVGCnl5z+/wHxvIBBCe5pNZ66IM15pGXQ4cDcfqCuP2kA==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-blur": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.2.4.tgz",
-      "integrity": "sha512-aLyXIoxy14bTansCPtbY8x7Sdn2OrrqkF/pcKiRXHJGGhi7wPacvB/NcmYJdnI/n2ExQ6V5Njuj/nfrsejVwcA==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-color-matrix": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.2.4.tgz",
-      "integrity": "sha512-DFtayybYXoUh73eHUFRK5REbi1t3FZuVUnaQTj+euHKF9L7EaYc3Q9wctpx1WPRcwkqEX50M4SNFhxpA7Pxtaw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-displacement": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.2.4.tgz",
-      "integrity": "sha512-Simq3IBJKt7+Gvk4kK7OFkfoeYUMhNhIyATCdeT+Jkdkq5WV7pYnH5hqO0YW7eAHrgjV13yn6t4H/GC4+6LhEA==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-fxaa": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.2.4.tgz",
-      "integrity": "sha512-qzKjdL+Ih18uGTJLg8tT/H+YCsTeGkw2uF7lyKnw/lxGLJQhLWIhM95M9qSNgxbXyW1vp7SbG81a9aAEz2HAhA==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-noise": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.2.4.tgz",
-      "integrity": "sha512-QAU9Ybj2ZQrWM9ZEjTTC0iLnQcuyNoZNRinxSbg1G0yacpmsSb9wvV5ltIZ66+hfY+90+u2Nudt/v9g6pvOdGg==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/graphics": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.2.4.tgz",
-      "integrity": "sha512-3A2EumTjWJgXlDLOyuBrl9b6v1Za/E+/IjOGUIX843HH4NYaf1a2sfDfljx6r3oiDvy+VhuBFmgynRcV5IyA0Q==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4",
-        "@pixi/sprite": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/math": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.2.4.tgz",
-      "integrity": "sha512-LJB+mozyEPllxa0EssFZrKNfVwysfaBun4b2dJKQQInp0DafgbA0j7A+WVg0oe51KhFULTJMpDqbLn/ITFc41A==",
-      "dev": true
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mesh": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.2.4.tgz",
-      "integrity": "sha512-wiALIqcRKib2BqeH9kOA5fOKWN352nqAspgbDa8gA7OyWzmNwqIedIlElixd0oLFOrIN5jOZAdzeKnoYQlt9Aw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mesh-extras": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.2.4.tgz",
-      "integrity": "sha512-Lxqq/1E2EmDgjZX8KzjhBy3VvITIQ00arr2ikyHYF1d0XtQTKEYpr8VKzhchqZ5/9DuyTDbDMYGhcxoNXQmZrQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/mesh": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.2.4.tgz",
-      "integrity": "sha512-95L/9nzfLHw6GoeqqRl/RjSloKvRt0xrc2inCmjMZvMsFUEtHN2F8IWd1k5vcv0S+83NCreFkJg6nJm1m5AZqg==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4",
-        "@pixi/sprite": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.2.4.tgz",
-      "integrity": "sha512-9g17KgSBEEhkinnKk4dqmxagzHOCPSTvGB6lOopBq4yyXmr/2WVv+QGjuzE0O+p80szQeBJjPBQxzrfBILaSRw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/display": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mixin-get-global-position": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.2.4.tgz",
-      "integrity": "sha512-UrAUF2BXCeWtFgR2m+er41Ky7zShT7r228cZkB6ZfYwMeThhwqG5mH68UeCyP6p68JMpT1gjI2DPfeSRY3ecnA==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/particle-container": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.2.4.tgz",
-      "integrity": "sha512-tpSzilZGFtAoi8XhzL0TecLPNRQAbY8nWV9XNGXJDw+nxXp18GCe8L6eEmnHLlAug67BRHl65DtrdvTknPX+4g==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4",
-        "@pixi/sprite": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/prepare": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.2.4.tgz",
-      "integrity": "sha512-Yff5Sh4kTLdKc5VkkM44LW9gpj7Izw8ns3P1TzWxqeGjzPZ3folr/tQujGL+Qw+8A9VESp+hX9MSIHyw+jpyrg==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4",
-        "@pixi/graphics": "7.2.4",
-        "@pixi/text": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/runner": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.2.4.tgz",
-      "integrity": "sha512-YtyqPk1LA+0guEFKSFx6t/YSvbEQwajFwi4Ft8iDhioa6VK2MmTir1GjWwy7JQYLcDmYSAcQjnmFtVTZohyYSw==",
-      "dev": true
-    },
-    "node_modules/pixi.js/node_modules/@pixi/settings": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.2.4.tgz",
-      "integrity": "sha512-ZPKRar9EwibijGmH8EViu4Greq1I/O7V/xQx2rNqN23XA7g09Qo6yfaeQpufu5xl8+/lZrjuHtQSnuY7OgG1CA==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "7.2.4",
-        "@types/css-font-loading-module": "^0.0.7",
-        "ismobilejs": "^1.1.0"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/sprite": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.2.4.tgz",
-      "integrity": "sha512-DhR1B+/d0eXpxHIesJMXcVPrKFwQ+zRA1LvEIFfzewqfaRN3X6PMIuoKX8SIb6tl+Hq8Ba9Pe28zI7d2rmRzrA==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/sprite-animated": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.2.4.tgz",
-      "integrity": "sha512-9eRriPSC0QVS7U9zQlrG3uEI5+h3fi+mqofXy+yjk1sGCmXSIJME5p2wg2mzxoJk3qkSMagQA9QHtL26Fti8Iw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/sprite": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/sprite-tiling": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.2.4.tgz",
-      "integrity": "sha512-nGfxQoACRx49dUN0oW1vFm3141M+7gkAbzoNJym2Pljd2dpLME9fb5E6Lyahu0yWMaPRhhGorn6z9VIGmTF3Jw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4",
-        "@pixi/sprite": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/spritesheet": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.2.4.tgz",
-      "integrity": "sha512-LNmlavyiMQeCF0U4S+yhzxUYmPmat6EpLjLnkGukQTZV5CZkxDCVgXM9uKoRF2DvNydj4yuwZ6+JjK8QssHI8Q==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/assets": "7.2.4",
-        "@pixi/core": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/text": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.2.4.tgz",
-      "integrity": "sha512-DGu7ktpe+zHhqR2sG9NsJt4mgvSObv5EqXTtUxD4Z0li1gmqF7uktpLyn5I6vSg1TTEL4TECClRDClVDGiykWw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/sprite": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/text-bitmap": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.2.4.tgz",
-      "integrity": "sha512-3u2CP4VN+muCaq/jtj7gn0hb3DET/X2S04zTBcgc2WVGufJc62yz+UDzS9jC+ellotVdt9c8U74++vpz3zJGfw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/assets": "7.2.4",
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4",
-        "@pixi/mesh": "7.2.4",
-        "@pixi/text": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/text-html": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.2.4.tgz",
-      "integrity": "sha512-0NfLAE/w51ZtatxVqLvDS62iO0VLKsSdctqTAVv4Zlgdk9TKJmX1WUucHJboTvbm2SbDjNDGfZ6qXM5nAslIDQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4",
-        "@pixi/sprite": "7.2.4",
-        "@pixi/text": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/ticker": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.2.4.tgz",
-      "integrity": "sha512-hQQHIHvGeFsP4GNezZqjzuhUgNQEVgCH9+qU05UX1Mc5UHC9l6OJnY4VTVhhcHxZjA6RnyaY+1zBxCnoXuazpg==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/extensions": "7.2.4",
-        "@pixi/settings": "7.2.4",
-        "@pixi/utils": "7.2.4"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/utils": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.2.4.tgz",
-      "integrity": "sha512-VUGQHBOINIS4ePzoqafwxaGPVRTa3oM/mEutIIHbNGI3b+QvSO+1Dnk40M0zcH6Bo+MxQZbOZK5X/wO9oU5+LQ==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/color": "7.2.4",
-        "@pixi/constants": "7.2.4",
-        "@pixi/settings": "7.2.4",
-        "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
-        "eventemitter3": "^4.0.0",
-        "url": "^0.11.0"
-      }
-    },
-    "node_modules/pixi.js/node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -500,19 +668,96 @@
       }
     },
     "node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true
     },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "dev": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
       "engines": {
-        "node": ">=0.4.x"
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sisteransi": {
@@ -536,61 +781,440 @@
       }
     },
     "node_modules/url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
       "dev": true,
       "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     }
   },
   "dependencies": {
-    "@pixi/color": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.2.4.tgz",
-      "integrity": "sha512-B/+9JRcXe2uE8wQfsueFRPZVayF2VEMRB7XGeRAsWCryOX19nmWhv0Nt3nOU2rvzI0niz9XgugJXsB6vVmDFSg==",
+    "@pixi/accessibility": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.4.3.tgz",
+      "integrity": "sha512-tCr0yeWpMe0yucFvEPidy5a7gVJGpTjqGrDpSEBYT/kbScfUwcoX49RrckCCCiXDlyO4WRh9lVVuHXTvqRLIMg==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/app": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.4.3.tgz",
+      "integrity": "sha512-opyWMuO0Ir8pf1DYUR++wAA6ZfNU+nIX2z95R2OD172HbcdhB4/HD7leLIIAny/LciEdMqlWEBhXK7N93YWbdg==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/assets": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.3.tgz",
+      "integrity": "sha512-StvjiJBSp/j9hHkGu8AFHNvwYUazXq64WhyhytztyDMRkg/l/cL7EcttY5T0qZNWlIpccdr60LUKrWDOuMpkiw==",
       "dev": true,
       "requires": {
-        "colord": "^2.9.3"
+        "@types/css-font-loading-module": "^0.0.12"
       }
     },
-    "@pixi/extensions": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.2.4.tgz",
-      "integrity": "sha512-Mnqv9scbL1ARD3QFKfOWs2aSVJJfP1dL8g5UiqGImYO3rZbz/9QCzXOeMVIZ5n3iaRyKMNhFFr84/zUja2H7Dw==",
+    "@pixi/color": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.4.3.tgz",
+      "integrity": "sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/colord": "^2.9.6"
+      }
+    },
+    "@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
       "dev": true
     },
+    "@pixi/compressed-textures": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.4.3.tgz",
+      "integrity": "sha512-uJ3CC+lNX4HIxs6IxEESO50/0A1KxSVm6CO9UlkXzTsNj9ynmdy5BkJ1dzii7LCdqGcHIXHO01yvKuUbJBBQtw==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/constants": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.3.tgz",
+      "integrity": "sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==",
+      "dev": true
+    },
+    "@pixi/core": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.3.tgz",
+      "integrity": "sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==",
+      "dev": true,
+      "requires": {
+        "@pixi/color": "7.4.3",
+        "@pixi/constants": "7.4.3",
+        "@pixi/extensions": "7.4.3",
+        "@pixi/math": "7.4.3",
+        "@pixi/runner": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@pixi/ticker": "7.4.3",
+        "@pixi/utils": "7.4.3"
+      }
+    },
+    "@pixi/display": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.3.tgz",
+      "integrity": "sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/events": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.3.tgz",
+      "integrity": "sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/extensions": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.3.tgz",
+      "integrity": "sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw==",
+      "dev": true
+    },
+    "@pixi/extract": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.4.3.tgz",
+      "integrity": "sha512-HNvGNrEVaeVsbcnIO1MsHpjZbTwo9nIlaOEBzDGcL6JWwzuB1RnzUke7WUCndCUt91sGUdvPnvgCvy9/NNFg3w==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/filter-alpha": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.4.3.tgz",
+      "integrity": "sha512-YFdUB1I53USQb+9TEhS849dV2KZhbnNGIoBbOSThUJfXQc4pDguIFWMagVToAQYgmZ4C4AtYfVjaSEELrMcCdA==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/filter-blur": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.4.3.tgz",
+      "integrity": "sha512-ZFzS9L/whdRbs5A/EUgF3yQaBcxNarmbuwaMgrfnpQ84mRczkGByqDLGToadiufyals07ufTrXBGRle9lbtEDA==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/filter-color-matrix": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.4.3.tgz",
+      "integrity": "sha512-TNu0h20SrzjUWIb5v19dAp1vPpqtG0w2XF9kIHN91bMNaf3R1jzhpWG6TtaVO9eo1IolWcEJLw38jIohyC+KNw==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/filter-displacement": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.4.3.tgz",
+      "integrity": "sha512-ax+cFA2mEnKgqf9F8qInpv09GNWzjwnASLETpwPXzWBtlAlNCeHV2tCv3+SlMdEKUkwG9sA7AmjjjC2JBUyt+Q==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/filter-fxaa": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.4.3.tgz",
+      "integrity": "sha512-y9jhho5cCflhEsPtNqqsd+XJHsb+/ysht4rG/VHQ8Z6pScHYpbgiEpowryGq8uSMQQwx6zKNS2DPiXdiOHPZsg==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/filter-noise": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.4.3.tgz",
+      "integrity": "sha512-rwgSO3BKe1jW/P5CaOcfLKjfpl674aBEo/igi/3QLxA3ORhILNqWRsKkOwP8xF/ejI5NE4rMEkdv0LScbdGFhA==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/graphics": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.3.tgz",
+      "integrity": "sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/math": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.3.tgz",
+      "integrity": "sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw==",
+      "dev": true
+    },
+    "@pixi/mesh": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.3.tgz",
+      "integrity": "sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/mesh-extras": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.4.3.tgz",
+      "integrity": "sha512-EqpxpVZoTObyupxMSzuUsCGmWPQioW84n9EO9Ajawkk/HYA+qKFZ5viKiEThIUBYgv4Apn/7c0U3Feg7Ez4uQQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/mixin-cache-as-bitmap": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.4.3.tgz",
+      "integrity": "sha512-NgvDdgSgd2tfcTSc+SWF12JJjVVz5ZrkSlhX0idSp/LSako82AiFJlD2xqH9GUsEcA6sqBBlnu7nrGkPTHQdhA==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/mixin-get-child-by-name": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.4.3.tgz",
+      "integrity": "sha512-HLhDxHwafQT+CxbqQx9w9ivJIyAOg9JJ/6m4fNymVuDWeuMGcxDxBD7DukdUYIieT+RD/RlxdPEmq8YoromlFA==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/mixin-get-global-position": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.4.3.tgz",
+      "integrity": "sha512-k09kvkS379EypCIWgXMY7uiXtWk1BsaJyTYlV16Co0AsmNPdFd+wUozMx1xV6rxcGiWXsxr/1k9fbETuYkcXCQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/particle-container": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.4.3.tgz",
+      "integrity": "sha512-0DfJF5C0XTfuI2FsLYvMKCOtqWjXWGOWfA6m4l0W/Ke/qw5zKIOEhgjPLw4qNRtOhmEfkVKJUGp66Ap/ya2YzA==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/prepare": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.4.3.tgz",
+      "integrity": "sha512-OjJHGKXPzwP5OLKxBnTBnKMOktHynLvO0TQPqTYgNtmGQzY109mypCqM4M+s/V+uYmBo/T+sXvBahj98q/f1tA==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/runner": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.3.tgz",
+      "integrity": "sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw==",
+      "dev": true
+    },
+    "@pixi/settings": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.4.3.tgz",
+      "integrity": "sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "7.4.3",
+        "@types/css-font-loading-module": "^0.0.12",
+        "ismobilejs": "^1.1.0"
+      }
+    },
+    "@pixi/sprite": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.3.tgz",
+      "integrity": "sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/sprite-animated": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.4.3.tgz",
+      "integrity": "sha512-mw5YIec8KfO1Jv9qrDNvGoD7Dlmcgww5YlMtd+ARi7Zzo+6ziNw899LXtoaKX1+3BXdZbYNyJAx3C5r30NtwXA==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/sprite-tiling": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.4.3.tgz",
+      "integrity": "sha512-kUa9cEcMsGXSIZoXA7LhW4oo0eWa30w0KYd7mZ0bqalBMfOcvsGZMN701Lc5lpE8URw+8yu5bnyGLbrxhWBTuw==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/spritesheet": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.4.3.tgz",
+      "integrity": "sha512-Ce4xZzUxUSKfiROUjjVCBYNLuCcDEWKJ822bSV9rkgVHItu3q04VnEww0DXO+9K0hKv4Ukjjk8aP6Pz0LgPm7A==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/text": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.3.tgz",
+      "integrity": "sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/text-bitmap": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.4.3.tgz",
+      "integrity": "sha512-TnBocJm7f5nMAYwYcsojc62uCrOYauAGH26o3pNrlqmHDRDQ7FzPOGvkYZGYFREbUycloLSRlYpSy0FB9ZdV4Q==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/text-html": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.4.3.tgz",
+      "integrity": "sha512-nm9K9gjSZAU8ETwQZBE3kMGNdO1IzyghxoRTcJCWKhekiGDpUQhopfNhqieNZ7reVJpvhpFQWjbyaHDehndUaQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "@pixi/ticker": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.3.tgz",
+      "integrity": "sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/extensions": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@pixi/utils": "7.4.3"
+      }
+    },
+    "@pixi/utils": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.3.tgz",
+      "integrity": "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==",
+      "dev": true,
+      "requires": {
+        "@pixi/color": "7.4.3",
+        "@pixi/constants": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^4.0.0",
+        "url": "^0.11.0"
+      }
+    },
     "@types/css-font-loading-module": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
+      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
       "dev": true
     },
     "@types/earcut": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
-      "integrity": "sha512-w8oigUCDjElRHRRrMvn/spybSMyX8MTkKA5Dv+tS1IE/TgmNZPqUYtvYBXGY8cieSE66gm+szeK+bnbxC2xHTQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
+      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
       "dev": true
     },
-    "@types/offscreencanvas": {
-      "version": "2019.7.0",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
-      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==",
-      "dev": true
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
     },
-    "colord": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-      "dev": true
+    "call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      }
+    },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
     },
     "earcut": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
       "dev": true
+    },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true
+    },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
     },
     "ismobilejs": {
       "version": "1.1.1",
@@ -604,320 +1228,54 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true
+    },
     "pixi.js": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.2.4.tgz",
-      "integrity": "sha512-nBH60meoLnHxoMFz17HoMxXS4uJpG5jwIdL+Gx2S11TzWgP3iKF+/WLOTrkSdyuQoQSdIBxVqpnYii0Wiox15A==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.4.3.tgz",
+      "integrity": "sha512-uIWdH0EI2dVgNoqN9aFaHCmR0V65OEhMkXs2sek3c/QP2ItV6UoM+ouX9esSv3ibo20F+J5D1XwnQhUZI6wqeQ==",
       "dev": true,
       "requires": {
-        "@pixi/accessibility": "7.2.4",
-        "@pixi/app": "7.2.4",
-        "@pixi/assets": "7.2.4",
-        "@pixi/compressed-textures": "7.2.4",
-        "@pixi/core": "7.2.4",
-        "@pixi/display": "7.2.4",
-        "@pixi/events": "7.2.4",
-        "@pixi/extensions": "7.2.4",
-        "@pixi/extract": "7.2.4",
-        "@pixi/filter-alpha": "7.2.4",
-        "@pixi/filter-blur": "7.2.4",
-        "@pixi/filter-color-matrix": "7.2.4",
-        "@pixi/filter-displacement": "7.2.4",
-        "@pixi/filter-fxaa": "7.2.4",
-        "@pixi/filter-noise": "7.2.4",
-        "@pixi/graphics": "7.2.4",
-        "@pixi/mesh": "7.2.4",
-        "@pixi/mesh-extras": "7.2.4",
-        "@pixi/mixin-cache-as-bitmap": "7.2.4",
-        "@pixi/mixin-get-child-by-name": "7.2.4",
-        "@pixi/mixin-get-global-position": "7.2.4",
-        "@pixi/particle-container": "7.2.4",
-        "@pixi/prepare": "7.2.4",
-        "@pixi/sprite": "7.2.4",
-        "@pixi/sprite-animated": "7.2.4",
-        "@pixi/sprite-tiling": "7.2.4",
-        "@pixi/spritesheet": "7.2.4",
-        "@pixi/text": "7.2.4",
-        "@pixi/text-bitmap": "7.2.4",
-        "@pixi/text-html": "7.2.4"
-      },
-      "dependencies": {
-        "@pixi/accessibility": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.2.4.tgz",
-          "integrity": "sha512-EVjuqUqv9FeYFXCv0S0qj1hgCtbAMNBPCbOGEtiMogpM++/IySxBZvcOYg3rRgo9inwt2s4Bi7kUiqMPD8hItw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/app": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.2.4.tgz",
-          "integrity": "sha512-eJ2jpu5P28ip07nLItw6sETXn45P4KR/leMJ6zPHRlhT1m8t5zTsWr3jK4Uj8LF2E+6KlPNzLQh5Alf/unn/aQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/assets": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.2.4.tgz",
-          "integrity": "sha512-7199re3wvMAlVqXLaCyAr8IkJSXqkeVAxcYyB2rBu4Id5m2hhlGX1dQsdMBiCXLwu6/LLVqDvJggSNVQBzL6ZQ==",
-          "dev": true,
-          "requires": {
-            "@types/css-font-loading-module": "^0.0.7"
-          }
-        },
-        "@pixi/compressed-textures": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.2.4.tgz",
-          "integrity": "sha512-atnWyw/ot/Wg69qhgskKiuTYCZx15IxV35sa0KyXMthyjyvDLCIvOn0nczM6wCBy9H96SjJbfgynVWhVrip6qw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/constants": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.2.4.tgz",
-          "integrity": "sha512-hKuHBWR6N4Q0Sf5MGF3/9l+POg/G5rqhueHfzofiuelnKg7aBs3BVjjZ+6hZbd6M++vOUmxYelEX/NEFBxrheA==",
-          "dev": true
-        },
-        "@pixi/core": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.2.4.tgz",
-          "integrity": "sha512-0XtvrfxHlS2T+beBBSpo7GI8+QLyyTqMVQpNmPqB4woYxzrOEJ9JaUFBaBfCvycLeUkfVih1u6HAbtF+2d1EjQ==",
-          "dev": true,
-          "requires": {
-            "@pixi/color": "7.2.4",
-            "@pixi/constants": "7.2.4",
-            "@pixi/extensions": "7.2.4",
-            "@pixi/math": "7.2.4",
-            "@pixi/runner": "7.2.4",
-            "@pixi/settings": "7.2.4",
-            "@pixi/ticker": "7.2.4",
-            "@pixi/utils": "7.2.4",
-            "@types/offscreencanvas": "^2019.6.4"
-          }
-        },
-        "@pixi/display": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.2.4.tgz",
-          "integrity": "sha512-w5tqb8cWEO5qIDaO9GEqRvxYhL0iMk0Wsngw23bbLm1gLEQmrFkB2tpJlRAqd7H82C3DrDDeWvkrrxW6+m4apg==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/events": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.2.4.tgz",
-          "integrity": "sha512-/JtmoB98fzIU8giN9xvlRvmvOi6u4MaD2DnKNOMHkQ1MBraj3pmrXM9fZ0JbNzi+324GraAAY76QidgHjIYoYQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/extract": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.2.4.tgz",
-          "integrity": "sha512-wlXZg+J2L/1jQhRi5nZQP/cXshovhjksjss91eAKMvY5aGxNAQovCP4xotJ/XJjfTvPMpeRzHPFYzm3PrOPQ7g==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/filter-alpha": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.2.4.tgz",
-          "integrity": "sha512-UTUMSGyktUr+I9vmigqJo9iUhb0nwGyqTTME2xBWZvVGCnl5z+/wHxvIBBCe5pNZ66IM15pGXQ4cDcfqCuP2kA==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/filter-blur": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.2.4.tgz",
-          "integrity": "sha512-aLyXIoxy14bTansCPtbY8x7Sdn2OrrqkF/pcKiRXHJGGhi7wPacvB/NcmYJdnI/n2ExQ6V5Njuj/nfrsejVwcA==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/filter-color-matrix": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.2.4.tgz",
-          "integrity": "sha512-DFtayybYXoUh73eHUFRK5REbi1t3FZuVUnaQTj+euHKF9L7EaYc3Q9wctpx1WPRcwkqEX50M4SNFhxpA7Pxtaw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/filter-displacement": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.2.4.tgz",
-          "integrity": "sha512-Simq3IBJKt7+Gvk4kK7OFkfoeYUMhNhIyATCdeT+Jkdkq5WV7pYnH5hqO0YW7eAHrgjV13yn6t4H/GC4+6LhEA==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/filter-fxaa": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.2.4.tgz",
-          "integrity": "sha512-qzKjdL+Ih18uGTJLg8tT/H+YCsTeGkw2uF7lyKnw/lxGLJQhLWIhM95M9qSNgxbXyW1vp7SbG81a9aAEz2HAhA==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/filter-noise": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.2.4.tgz",
-          "integrity": "sha512-QAU9Ybj2ZQrWM9ZEjTTC0iLnQcuyNoZNRinxSbg1G0yacpmsSb9wvV5ltIZ66+hfY+90+u2Nudt/v9g6pvOdGg==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/graphics": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.2.4.tgz",
-          "integrity": "sha512-3A2EumTjWJgXlDLOyuBrl9b6v1Za/E+/IjOGUIX843HH4NYaf1a2sfDfljx6r3oiDvy+VhuBFmgynRcV5IyA0Q==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/math": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.2.4.tgz",
-          "integrity": "sha512-LJB+mozyEPllxa0EssFZrKNfVwysfaBun4b2dJKQQInp0DafgbA0j7A+WVg0oe51KhFULTJMpDqbLn/ITFc41A==",
-          "dev": true
-        },
-        "@pixi/mesh": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.2.4.tgz",
-          "integrity": "sha512-wiALIqcRKib2BqeH9kOA5fOKWN352nqAspgbDa8gA7OyWzmNwqIedIlElixd0oLFOrIN5jOZAdzeKnoYQlt9Aw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/mesh-extras": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.2.4.tgz",
-          "integrity": "sha512-Lxqq/1E2EmDgjZX8KzjhBy3VvITIQ00arr2ikyHYF1d0XtQTKEYpr8VKzhchqZ5/9DuyTDbDMYGhcxoNXQmZrQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/mixin-cache-as-bitmap": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.2.4.tgz",
-          "integrity": "sha512-95L/9nzfLHw6GoeqqRl/RjSloKvRt0xrc2inCmjMZvMsFUEtHN2F8IWd1k5vcv0S+83NCreFkJg6nJm1m5AZqg==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/mixin-get-child-by-name": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.2.4.tgz",
-          "integrity": "sha512-9g17KgSBEEhkinnKk4dqmxagzHOCPSTvGB6lOopBq4yyXmr/2WVv+QGjuzE0O+p80szQeBJjPBQxzrfBILaSRw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/mixin-get-global-position": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.2.4.tgz",
-          "integrity": "sha512-UrAUF2BXCeWtFgR2m+er41Ky7zShT7r228cZkB6ZfYwMeThhwqG5mH68UeCyP6p68JMpT1gjI2DPfeSRY3ecnA==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/particle-container": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.2.4.tgz",
-          "integrity": "sha512-tpSzilZGFtAoi8XhzL0TecLPNRQAbY8nWV9XNGXJDw+nxXp18GCe8L6eEmnHLlAug67BRHl65DtrdvTknPX+4g==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/prepare": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.2.4.tgz",
-          "integrity": "sha512-Yff5Sh4kTLdKc5VkkM44LW9gpj7Izw8ns3P1TzWxqeGjzPZ3folr/tQujGL+Qw+8A9VESp+hX9MSIHyw+jpyrg==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/runner": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.2.4.tgz",
-          "integrity": "sha512-YtyqPk1LA+0guEFKSFx6t/YSvbEQwajFwi4Ft8iDhioa6VK2MmTir1GjWwy7JQYLcDmYSAcQjnmFtVTZohyYSw==",
-          "dev": true
-        },
-        "@pixi/settings": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.2.4.tgz",
-          "integrity": "sha512-ZPKRar9EwibijGmH8EViu4Greq1I/O7V/xQx2rNqN23XA7g09Qo6yfaeQpufu5xl8+/lZrjuHtQSnuY7OgG1CA==",
-          "dev": true,
-          "requires": {
-            "@pixi/constants": "7.2.4",
-            "@types/css-font-loading-module": "^0.0.7",
-            "ismobilejs": "^1.1.0"
-          }
-        },
-        "@pixi/sprite": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.2.4.tgz",
-          "integrity": "sha512-DhR1B+/d0eXpxHIesJMXcVPrKFwQ+zRA1LvEIFfzewqfaRN3X6PMIuoKX8SIb6tl+Hq8Ba9Pe28zI7d2rmRzrA==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/sprite-animated": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.2.4.tgz",
-          "integrity": "sha512-9eRriPSC0QVS7U9zQlrG3uEI5+h3fi+mqofXy+yjk1sGCmXSIJME5p2wg2mzxoJk3qkSMagQA9QHtL26Fti8Iw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/sprite-tiling": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.2.4.tgz",
-          "integrity": "sha512-nGfxQoACRx49dUN0oW1vFm3141M+7gkAbzoNJym2Pljd2dpLME9fb5E6Lyahu0yWMaPRhhGorn6z9VIGmTF3Jw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/spritesheet": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.2.4.tgz",
-          "integrity": "sha512-LNmlavyiMQeCF0U4S+yhzxUYmPmat6EpLjLnkGukQTZV5CZkxDCVgXM9uKoRF2DvNydj4yuwZ6+JjK8QssHI8Q==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/text": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.2.4.tgz",
-          "integrity": "sha512-DGu7ktpe+zHhqR2sG9NsJt4mgvSObv5EqXTtUxD4Z0li1gmqF7uktpLyn5I6vSg1TTEL4TECClRDClVDGiykWw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/text-bitmap": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.2.4.tgz",
-          "integrity": "sha512-3u2CP4VN+muCaq/jtj7gn0hb3DET/X2S04zTBcgc2WVGufJc62yz+UDzS9jC+ellotVdt9c8U74++vpz3zJGfw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/text-html": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.2.4.tgz",
-          "integrity": "sha512-0NfLAE/w51ZtatxVqLvDS62iO0VLKsSdctqTAVv4Zlgdk9TKJmX1WUucHJboTvbm2SbDjNDGfZ6qXM5nAslIDQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/ticker": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.2.4.tgz",
-          "integrity": "sha512-hQQHIHvGeFsP4GNezZqjzuhUgNQEVgCH9+qU05UX1Mc5UHC9l6OJnY4VTVhhcHxZjA6RnyaY+1zBxCnoXuazpg==",
-          "dev": true,
-          "requires": {
-            "@pixi/extensions": "7.2.4",
-            "@pixi/settings": "7.2.4",
-            "@pixi/utils": "7.2.4"
-          }
-        },
-        "@pixi/utils": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.2.4.tgz",
-          "integrity": "sha512-VUGQHBOINIS4ePzoqafwxaGPVRTa3oM/mEutIIHbNGI3b+QvSO+1Dnk40M0zcH6Bo+MxQZbOZK5X/wO9oU5+LQ==",
-          "dev": true,
-          "requires": {
-            "@pixi/color": "7.2.4",
-            "@pixi/constants": "7.2.4",
-            "@pixi/settings": "7.2.4",
-            "@types/earcut": "^2.1.0",
-            "earcut": "^2.2.4",
-            "eventemitter3": "^4.0.0",
-            "url": "^0.11.0"
-          }
-        },
-        "eventemitter3": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-          "dev": true
-        }
+        "@pixi/accessibility": "7.4.3",
+        "@pixi/app": "7.4.3",
+        "@pixi/assets": "7.4.3",
+        "@pixi/compressed-textures": "7.4.3",
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/events": "7.4.3",
+        "@pixi/extensions": "7.4.3",
+        "@pixi/extract": "7.4.3",
+        "@pixi/filter-alpha": "7.4.3",
+        "@pixi/filter-blur": "7.4.3",
+        "@pixi/filter-color-matrix": "7.4.3",
+        "@pixi/filter-displacement": "7.4.3",
+        "@pixi/filter-fxaa": "7.4.3",
+        "@pixi/filter-noise": "7.4.3",
+        "@pixi/graphics": "7.4.3",
+        "@pixi/mesh": "7.4.3",
+        "@pixi/mesh-extras": "7.4.3",
+        "@pixi/mixin-cache-as-bitmap": "7.4.3",
+        "@pixi/mixin-get-child-by-name": "7.4.3",
+        "@pixi/mixin-get-global-position": "7.4.3",
+        "@pixi/particle-container": "7.4.3",
+        "@pixi/prepare": "7.4.3",
+        "@pixi/sprite": "7.4.3",
+        "@pixi/sprite-animated": "7.4.3",
+        "@pixi/sprite-tiling": "7.4.3",
+        "@pixi/spritesheet": "7.4.3",
+        "@pixi/text": "7.4.3",
+        "@pixi/text-bitmap": "7.4.3",
+        "@pixi/text-html": "7.4.3"
       }
     },
     "prompts": {
@@ -931,16 +1289,67 @@
       }
     },
     "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "dev": true
+    "qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "requires": {
+        "side-channel": "^1.1.0"
+      }
+    },
+    "side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      }
+    },
+    "side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      }
+    },
+    "side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      }
+    },
+    "side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -955,13 +1364,13 @@
       "dev": true
     },
     "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
       "dev": true,
       "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/CarlosFdez/world-explorer#readme",
   "devDependencies": {
-    "pixi.js": "^7.2.4",
+    "pixi.js": "^7.4.3",
     "prompts": "^2.4.2",
     "typescript": "^4.7.4"
   }

--- a/styles/style.css
+++ b/styles/style.css
@@ -1,6 +1,0 @@
-#world-explorer-opacity-adjuster {
-    align-items: center;
-    justify-content: center;
-    padding: 0 16px;
-    min-height: 32px;
-}

--- a/styles/world-explorer.css
+++ b/styles/world-explorer.css
@@ -1,0 +1,5 @@
+#world-explorer-opacity-adjuster {
+    justify-content: center;
+    padding: 12px 16px;
+    min-height: 80px;
+}

--- a/templates/opacity-adjuster.hbs
+++ b/templates/opacity-adjuster.hbs
@@ -1,3 +1,6 @@
 <div>
-    <input type="range" value="{{opacityGM}}" min="0" max="1" step="0.05"/>
+    <label>{{localize "WorldExplorer.Tools.Opacity.Partial"}}</label>
+    <range-picker name="flags.world-explorer.partialOpacityGM" value="{{partialOpacityGM}}" min="0" max="1" step="0.05"></range-picker>
+    <label>{{localize "WorldExplorer.Tools.Opacity.Hidden"}}</label>
+    <range-picker name="flags.world-explorer.opacityGM" value="{{opacityGM}}" min="0" max="1" step="0.05"></range-picker>
 </div>

--- a/templates/scene-settings.hbs
+++ b/templates/scene-settings.hbs
@@ -1,62 +1,93 @@
-<div class="tab {{#if tab.active}} active{{/if}}" data-group="sheet" data-tab="worldExplorer">
+<div class="tab scrollable {{#if tab.active}} active{{/if}}" data-group="sheet" data-tab="worldExplorer">
+    {{!-- Enable --}}
     <div class="form-group">
         <label for="WorldExplorer-Enabled-{{document.id}}">{{localize "WorldExplorer.SceneSettings.Enabled"}}</label>
         <input id="WorldExplorer-Enabled-{{document.id}}" type="checkbox" name="flags.world-explorer.enabled" {{checked enabled}}/>
     </div>
-
+    {{!-- Image --}}
     <div class="form-group">
-        <label>{{localize "WorldExplorer.SceneSettings.Color"}}</label>
+        <label>{{localize "WorldExplorer.SceneSettings.Image.Label"}}</label>
         <div class="form-fields">
-            <input type="text" name="flags.world-explorer.color" value="{{color}}" placeholder="Default (#000000)" data-dtype="String"/>
+            <file-picker name="flags.world-explorer.image" type="imagevideo" value="{{image}}"></file-picker>
         </div>
     </div>
+    {{!-- Color --}}
     <div class="form-group">
-        <label>{{localize "WorldExplorer.SceneSettings.Image"}}</label>
+        <label>{{localize "WorldExplorer.SceneSettings.Colors.Overlay.Label"}}</label>
         <div class="form-fields">
-            <button type="button" class="file-picker" data-type="imagevideo" data-target="flags.world-explorer.image" title="Browse Files" tabindex="-1">
-                <i class="fa-solid fa-file-import fa-fw"></i>
-            </button>
-            <input class="image" type="text" name="flags.world-explorer.image" placeholder="File Path" value="{{image}}">
+            <color-picker name="flags.world-explorer.color" value="{{color}}"  placeholder="Default (#000000)"></color-picker>
         </div>
+        <p class="hint">{{localize "WorldExplorer.SceneSettings.Colors.Overlay.Hint"}}</p>
     </div>
+    {{!-- Partial Color --}}
     <div class="form-group">
-        <label>{{localize "WorldExplorer.SceneSettings.Persist_Explored_Areas"}}</label>
-        <input type="checkbox" name="flags.world-explorer.persistExploredAreas" {{checked persistExploredAreas}}/>
+        <label>{{localize "WorldExplorer.SceneSettings.Colors.Partial.Label"}}</label>
+        <div class="form-fields">
+            <color-picker name="flags.world-explorer.partialColor" value="{{partialColor}}" placeholder="Default (same as above)"></color-picker>
+        </div>
+        <p class="hint">{{localize "WorldExplorer.SceneSettings.Colors.Partial.Hint"}}</p>
     </div>
-
-    <fieldset>
-        <div class="form-group">
-            <label>{{localize "WorldExplorer.SceneSettings.Position.Name"}}</label>
-            <div class="form-fields">
-                <select name="flags.world-explorer.position">
-                    {{selectOptions POSITION_OPTIONS selected=position localize=true}}
-                </select>
-            </div>
-            <p class="hint">{{localize "WorldExplorer.SceneSettings.Position.Hint"}}</p>
+    {{!-- Overlay Position --}}
+    <div class="form-group">
+        <label>{{localize "WorldExplorer.SceneSettings.Position.Label"}}</label>
+        <div class="form-fields">
+            <select name="flags.world-explorer.position">
+                {{selectOptions POSITION_OPTIONS selected=position localize=true}}
+            </select>
         </div>
-        <div class="form-group">
-            <label>{{localize "WorldExplorer.SceneSettings.Reveal"}}</label>
-            <div class="form-fields">
-                <input type="text" name="flags.world-explorer.revealRadius" value="{{revealRadius}}">
-            </div>
+        <p class="hint">{{localize "WorldExplorer.SceneSettings.Position.Hint"}}</p>
+    </div>
+    {{!-- Extend Revealed Tiles --}}
+    <div class="form-group slim">
+        <label>{{localize "WorldExplorer.SceneSettings.GridReveal.Label"}} <span class="units">({{units}})</span></label>
+        <div class="form-fields">
+            <input type="number" name="flags.world-explorer.gridRevealRadius" value="{{gridRevealRadius}}">
         </div>
+        <p class="hint">{{localize "WorldExplorer.SceneSettings.GridReveal.Hint"}}</p>
+    </div>
+    {{!-- GM Opacity --}}
+    <fieldset class="world-explorer-setting">
+        <legend><i class="fa-solid fa-crown"></i> {{localize "WorldExplorer.SceneSettings.Opacity.Title" role=roles.gm}}</legend>
         <div class="form-group">
-            <label>{{localize "WorldExplorer.SceneSettings.GridReveal.Name"}}</label>
+            <label>{{localize "WorldExplorer.SceneSettings.Opacity.Partial"}}</label>
             <div class="form-fields">
-                <input type="text" name="flags.world-explorer.gridRevealRadius" value="{{gridRevealRadius}}">
-            </div>
-            <p class="hint">{{localize "WorldExplorer.SceneSettings.GridReveal.Hint"}}</p>
-        </div>
-        <div class="form-group">
-            <label>{{localize "WorldExplorer.SceneSettings.GM_Opacity"}}</label>
-            <div class="form-fields">
-                <range-picker name="flags.world-explorer.opacityGM" value="{{opacityGM}}" min="0" max="1" step="0.05" />
+                <range-picker name="flags.world-explorer.partialOpacityGM" value="{{partialOpacityGM}}" min="0" max="1" step="0.05"></range-picker>
             </div>
         </div>
         <div class="form-group">
-            <label>{{localize "WorldExplorer.SceneSettings.Player_Opacity"}}</label>
+            <label>{{localize "WorldExplorer.SceneSettings.Opacity.Hidden"}}</label>
             <div class="form-fields">
-                <range-picker name="flags.world-explorer.opacityPlayer" value="{{opacityPlayer}}" min="0" max="1" step="0.05" />
+                <range-picker name="flags.world-explorer.opacityGM" value="{{opacityGM}}" min="0" max="1" step="0.05"></range-picker>
+            </div>
+        </div>
+    </fieldset>
+    {{!-- Player Opacity --}}
+    <fieldset class="world-explorer-setting">
+        <legend><i class="fa-solid fa-users"></i> {{localize "WorldExplorer.SceneSettings.Opacity.Title" role=roles.player}}</legend>
+        <div class="form-group">
+            <label>{{localize "WorldExplorer.SceneSettings.Opacity.Partial"}}</label>
+            <div class="form-fields">
+                <range-picker name="flags.world-explorer.partialOpacityPlayer" value="{{partialOpacityPlayer}}" min="0" max="1" step="0.05"></range-picker>
+            </div>
+        </div>
+        <div class="form-group">
+            <label>{{localize "WorldExplorer.SceneSettings.Opacity.Hidden"}}</label>
+            <div class="form-fields">
+                <range-picker name="flags.world-explorer.opacityPlayer" value="{{opacityPlayer}}" min="0" max="1" step="0.05"></range-picker>
+            </div>
+        </div>
+    </fieldset>
+    {{!-- Token Interactions --}}
+    <fieldset class="world-explorer-setting">
+        <legend><i class="fa-solid fa-circle-user"></i> {{localize "WorldExplorer.SceneSettings.TokenInteractions.Title"}}</legend>
+        <div class="form-group">
+            <label for="WorldExplorer-persistExploredAreas">{{localize "WorldExplorer.SceneSettings.TokenInteractions.PersistExplored"}}</label>
+            <input id="WorldExplorer-persistExploredAreas" type="checkbox" name="flags.world-explorer.persistExploredAreas" {{checked persistExploredAreas}}/>
+        </div>
+        <div class="form-group slim">
+            <label>{{localize "WorldExplorer.SceneSettings.TokenInteractions.TokenReveal"}} <span class="units">({{units}})</span></label>
+            <div class="form-fields">
+                <input type="number" name="flags.world-explorer.revealRadius" value="{{revealRadius}}">
             </div>
         </div>
     </fieldset>


### PR DESCRIPTION
Another attempt by me to convince you to implement this feature of allowing partly revealed tiles, feature request #14.

I have been using my edited version up until now with great success, but with the transition to v13 I have gone ahead and merged my implementation with your excellent changes to make this module v13 compatible. Thank you so much for doing the hard work on using AppV2!

I have improved upon my previous implementation in PR #49. Now there are only two PixiJS layers with two masks. I was able to merge the existing two layers, the one for the color and the one for the image, to one. Unfortunately, I did have to add another layer to allow for the partly revealed tiles to have their separate color. Because of the extra color requirement it is not possible to do all this in one layer and also be able to mask an overlay image.

There are a bunch of other fixes and improvements, see below for a more comprehensive list of changes.

I sincerely hope that you approve of these additions and will merge this PR. It has been quite a lot of work! I have tried to keep the coding style the same, not changed the font awesome `fa-solid` to `fas`, and found a way to not need as many PixiJS layers (as mentioned above). I hope this addresses all the concerns [you mentioned](https://github.com/CarlosFdez/world-explorer/pull/49#issuecomment-2461139293).

## Screenshots
<img width="774" height="614" alt="image" src="https://github.com/user-attachments/assets/392742ca-faf0-474e-85b9-3799479277bb" />

> Example of partly revealed tiles in different color (blue) than the hidden tiles (grey)

&nbsp;

<img width="561" height="964" alt="image" src="https://github.com/user-attachments/assets/32dc51a5-c784-4ac0-961c-9ce1db7ef111" />

> The scene config changes

&nbsp;

<img width="332" height="408" alt="image" src="https://github.com/user-attachments/assets/c9500193-9e92-4b25-942b-d0def035f816" />

> Tool menu changes

&nbsp;

## Changes
* Add support for partially revealed tiles with their own colour
* Merge the hidden tiles and image layer into one to reduce overhead
* Add layer to support partially revealed tiles having their own colour
* Change flag from `revealedPositions` to `gridPositions` so its clear whether or not migration is needed
* Add 3rd attribute to each entry in `gridPositions` array to denote the state of the grid entity, "reveal" or "partial"
* Fix deprecation warning for SceneConfig
* Change the dev PIXI.js version to match version used by Foundry v13 (7.4.3)
* Bump version number to v2.1.0
* Updated tool icons (on the left) and add option to make tiles partly revealed
* Add partly revealed slider to GM Opacity Adjuster
* Swap `input` for `range-picker` for GM Opacity Adjuster, so it works the same as in the scene settings
* Add partly revealed option to Reset dialog
* Overhaul World Explorer scene settings to:
  * Include partly revealed color
  * Fix **bug** not working Filepicker for overlay image
  * Add color pickers for overlay & partial color
  * Change presentation to be clearer
* Update localisation to fit new scene settings
* Fix **bug** thrown because `DEFAULT_SETTINGS` is not available in opacity-slider.mjs
* Fix **bug** that canvas is not updating if revealRadius is not set (add `force` to refreshThrottled)
* Address **bugs** with the tools and switching between scenes:
  * Close opacity slider
  * Switch to token tools when switching to a scene that doesn't have World Explorer enabled while the World Explorer tools are active, because otherwise Foundry hangs
  * Fix not being able to use the currently selected World Explorer tool when switching between scenes that both have World Explorer enabled
* Update Font Awesome icons [deprecated in v6](https://docs.fontawesome.com/v6/web/setup/upgrade/whats-changed):
  * fa-random is now fa-shuffle
  * fa-times is now fa-xmark
* Rename css file to world-explorer.css because it is easier to troubleshoot