### PR TITLE
Use single pixi layer

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,10 +1,7 @@
 {
     "WorldExplorer": {
         "Name": "World Explorer",
-        "Settings": {
-        },
         "SceneSettings": {
-            "Description": "Configure settings for the World Explorer module",
             "Enabled": "Enable the module to work for this scene",
             "Color": "Overlay Color",
             "Image": "Overlay Image",
@@ -36,7 +33,7 @@
         },
         "ResetDialog": {
             "Title": "Reset Scene?",
-            "Content": "Are you sure you want to reset and update the entire scene?",
+            "Content": "Are you sure you want to reset and update the entire scene?</br>This can't be undone!",
             "Confirm": "Type this exact code in the box below in order to proceed: <strong>{code}</strong>",
             "Choices": {
                 "Explored": "Show All",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1,10 +1,7 @@
 {
     "WorldExplorer": {
         "Name": "ワールドマスク",
-        "Settings": {
-        },
         "SceneSettings": {
-            "Description": "ワールドマスクの設定",
             "Enabled": "このシーンでModを使用する",
             "Color": "マスク色",
             "Image": "マスク画像",

--- a/module/opacity-slider.mjs
+++ b/module/opacity-slider.mjs
@@ -58,8 +58,8 @@ export class OpacityGMAdjuster extends fapi.HandlebarsApplicationMixin(fapi.Appl
 
         element.addEventListener("input", (event) => {
             const value = Number(event.target.value);
-            const updateId = event.target.parentNode.name;
-            this.scene.update({ [updateId]: value });
+            const property = event.target.closest("[name]").name;
+            this.scene.update({ [property]: value });
         });
     }
 

--- a/module/opacity-slider.mjs
+++ b/module/opacity-slider.mjs
@@ -56,16 +56,16 @@ export class OpacityGMAdjuster extends fapi.HandlebarsApplicationMixin(fapi.Appl
             element.style.top = `${bounds.top}px`;
         }
 
-        const slider = element.querySelector("[type=range]");
-        slider?.addEventListener("input", (event) => {
+        element.addEventListener("input", (event) => {
             const value = Number(event.target.value);
-            this.scene.update({ "flags.world-explorer.opacityGM": value });
+            const updateId = event.target.parentNode.name;
+            this.scene.update({ [updateId]: value });
         });
     }
 
     detectClose(controls = {}) {
         if (controls.control?.name !== "worldExplorer" && this.rendered) {
-            $("#world-explorer-opacity-adjuster").fadeOut(() => {
+            $(`#${this.id}`).fadeOut(() => {
                 this.close({ force: true });
             });
         }
@@ -73,12 +73,10 @@ export class OpacityGMAdjuster extends fapi.HandlebarsApplicationMixin(fapi.Appl
 
     toggleVisibility() {
         if (this.rendered) {
-            $("#world-explorer-opacity-adjuster").fadeOut(() => {
-                this.close({ force: true });
-            });
+            this.detectClose();
         } else {
             this.render({ force: true, scene: canvas.scene }).then(() => {
-                $("#world-explorer-opacity-adjuster").hide().fadeIn();
+                $(`#${this.id}`).hide().fadeIn({duration: 250});
             });
         }
     }

--- a/module/opacity-slider.mjs
+++ b/module/opacity-slider.mjs
@@ -63,8 +63,8 @@ export class OpacityGMAdjuster extends fapi.HandlebarsApplicationMixin(fapi.Appl
         });
     }
 
-    detectClose(controls) {
-        if (controls.control.name !== "worldExplorer" && this.rendered) {
+    detectClose(controls = {}) {
+        if (controls.control?.name !== "worldExplorer" && this.rendered) {
             $("#world-explorer-opacity-adjuster").fadeOut(() => {
                 this.close({ force: true });
             });

--- a/module/world-explorer-layer.mjs
+++ b/module/world-explorer-layer.mjs
@@ -128,13 +128,7 @@ export class WorldExplorerLayer extends foundry.canvas.layers.InteractionLayer {
         this.addChild(this.fogSprite);
         this.addChild(this.mask);
 
-        const flags = this.settings;
-        this.alpha = (game.user.isGM ? flags.opacityGM : flags.opacityPlayer) ?? 1;
-        this.color = flags.color;
-        this.image = flags.image;
-        this._enabled = flags.enabled;
-
-        this.visible = this._enabled;
+        this.updateSettings();
 
         this.#migratePositions();
     }
@@ -169,11 +163,8 @@ export class WorldExplorerLayer extends foundry.canvas.layers.InteractionLayer {
         const flags = this.settings;
         const imageChanged = this.image !== flags.image;
         const becameEnabled = !this.enabled && flags.enabled;
-        this.alpha = (game.user.isGM ? flags.opacityGM : flags.opacityPlayer) ?? 1;
-        this.color = flags.color;
-        this.image = flags.image;
-        this._enabled = flags.enabled;
-        this.visible = this._enabled;
+
+        this.updateSettings();
 
         this.refreshMask();
         if (becameEnabled) {
@@ -182,6 +173,16 @@ export class WorldExplorerLayer extends foundry.canvas.layers.InteractionLayer {
         if (imageChanged || !flags.enabled || becameEnabled) {
             this.refreshImage();
         }
+    }
+
+    /** Set the settings to `this` on initialize and updates. */
+    updateSettings() {
+        const flags = this.settings;
+        this.hiddenAlpha = (game.user.isGM ? flags.opacityGM : flags.opacityPlayer) ?? 1;
+        this.color = flags.color;
+        this.image = flags.image;
+        this._enabled = flags.enabled;
+        this.visible = this._enabled;
     }
 
     onChangeTool(toolName) {
@@ -221,7 +222,7 @@ export class WorldExplorerLayer extends foundry.canvas.layers.InteractionLayer {
     }
 
     refreshOverlay() {
-        if (!this.enabled || this.alpha === 0) return;
+        if (!this.enabled || this.hiddenAlpha === 0) return;
         this.overlayBackground.beginFill(0xFFFFFF);
         this.overlayBackground.drawRect(0, 0, canvas.dimensions.width, canvas.dimensions.height);
         this.overlayBackground.endFill();
@@ -229,9 +230,9 @@ export class WorldExplorerLayer extends foundry.canvas.layers.InteractionLayer {
     }
 
     refreshMask() {
-        if (!this.enabled || this.alpha === 0) return;
+        if (!this.enabled) return;
         const graphic = new PIXI.Graphics();
-        graphic.beginFill(0xFFFFFF);
+        graphic.beginFill(0xFFFFFF, this.hiddenAlpha);
         graphic.drawRect(0, 0, canvas.dimensions.width, canvas.dimensions.height);
         graphic.endFill();
 

--- a/module/world-explorer-layer.mjs
+++ b/module/world-explorer-layer.mjs
@@ -120,15 +120,17 @@ export class WorldExplorerLayer extends foundry.canvas.layers.InteractionLayer {
         this.hiddenTiles.position.set(x, y);
         this.hiddenTiles.width = width;
         this.hiddenTiles.height = height;
+
         // Create a mask for it, with a texture we can reference later to update the mask
         this.hiddenTilesMaskTexture = createPlainTexture();
         this.hiddenTiles.mask = new PIXI.Sprite(this.hiddenTilesMaskTexture);
         this.hiddenTiles.mask.position.set(x, y);
+
         // Add to the layer
         this.addChild(this.hiddenTiles);
         this.addChild(this.hiddenTiles.mask);
 
-        this.updateSettings();
+        this.#syncSettings();
 
         this.#migratePositions();
     }
@@ -156,7 +158,7 @@ export class WorldExplorerLayer extends foundry.canvas.layers.InteractionLayer {
         const imageChanged = this.image !== flags.image;
         const becameEnabled = !this.enabled && flags.enabled;
 
-        this.updateSettings();
+        this.#syncSettings();
 
         this.refreshMask();
         if (becameEnabled) {
@@ -169,8 +171,8 @@ export class WorldExplorerLayer extends foundry.canvas.layers.InteractionLayer {
         }
     }
 
-    /** Set the settings to `this` on initialize and updates. */
-    updateSettings() {
+    /** Reads flags and updates variables to match */
+    #syncSettings() {
         const flags = this.settings;
         this.hiddenAlpha = (game.user.isGM ? flags.opacityGM : flags.opacityPlayer) ?? DEFAULT_SETTINGS.opacityPlayer;
         this.color = flags.color;
@@ -205,7 +207,7 @@ export class WorldExplorerLayer extends foundry.canvas.layers.InteractionLayer {
     }
 
     refreshImage(image = null) {
-        if (image) this.image = image;
+        this.image ??= image;
         if (this.enabled && this.image) {
             foundry.canvas.loadTexture(this.image).then((texture) => {
                 this.hiddenTiles.texture = texture;

--- a/module/world-explorer-layer.mjs
+++ b/module/world-explorer-layer.mjs
@@ -224,15 +224,10 @@ export class WorldExplorerLayer extends foundry.canvas.layers.InteractionLayer {
     }
 
     refreshColors() {
-        if (!this.enabled || this.hiddenAlpha === 0) return;
+        if (!this.enabled) return;
 
         // Set the color of the layers, but only if no image is present
-        if (!this.image) {
-            this.hiddenTiles.tint = Color.from(this.color);
-        } else {
-            // Reset the color if an image is present, otherwise it gets colored
-            this.hiddenTiles.tint = 0xFFFFFF;
-        }
+        this.hiddenTiles.tint = !this.image ? Color.from(this.color) : 0xFFFFFF;
     }
 
     refreshMask() {

--- a/templates/opacity-adjuster.hbs
+++ b/templates/opacity-adjuster.hbs
@@ -1,3 +1,3 @@
 <div>
-    <input type="range" value="{{opacityGM}}" min="0" max="1" step="0.05"/>
+    <range-picker name="flags.world-explorer.opacityGM" value="{{opacityGM}}" min="0" max="1" step="0.05"></range-picker>
 </div>

--- a/templates/scene-settings.hbs
+++ b/templates/scene-settings.hbs
@@ -1,4 +1,4 @@
-<div class="tab {{#if tab.active}} active{{/if}}" data-group="sheet" data-tab="worldExplorer">
+<div class="tab scrollable {{#if tab.active}}active{{/if}}" data-group="sheet" data-tab="worldExplorer">
     <div class="form-group">
         <label for="WorldExplorer-Enabled-{{document.id}}">{{localize "WorldExplorer.SceneSettings.Enabled"}}</label>
         <input id="WorldExplorer-Enabled-{{document.id}}" type="checkbox" name="flags.world-explorer.enabled" {{checked enabled}}/>
@@ -7,16 +7,13 @@
     <div class="form-group">
         <label>{{localize "WorldExplorer.SceneSettings.Color"}}</label>
         <div class="form-fields">
-            <input type="text" name="flags.world-explorer.color" value="{{color}}" placeholder="Default (#000000)" data-dtype="String"/>
+            <color-picker name="flags.world-explorer.color" value="{{color}}"  placeholder="Default (#000000)"></color-picker>
         </div>
     </div>
     <div class="form-group">
         <label>{{localize "WorldExplorer.SceneSettings.Image"}}</label>
         <div class="form-fields">
-            <button type="button" class="file-picker" data-type="imagevideo" data-target="flags.world-explorer.image" title="Browse Files" tabindex="-1">
-                <i class="fa-solid fa-file-import fa-fw"></i>
-            </button>
-            <input class="image" type="text" name="flags.world-explorer.image" placeholder="File Path" value="{{image}}">
+            <file-picker name="flags.world-explorer.image" type="imagevideo" value="{{image}}"></file-picker>
         </div>
     </div>
     <div class="form-group">
@@ -37,13 +34,13 @@
         <div class="form-group">
             <label>{{localize "WorldExplorer.SceneSettings.Reveal"}}</label>
             <div class="form-fields">
-                <input type="text" name="flags.world-explorer.revealRadius" value="{{revealRadius}}">
+                <input type="number" name="flags.world-explorer.revealRadius" value="{{revealRadius}}">
             </div>
         </div>
         <div class="form-group">
             <label>{{localize "WorldExplorer.SceneSettings.GridReveal.Name"}}</label>
             <div class="form-fields">
-                <input type="text" name="flags.world-explorer.gridRevealRadius" value="{{gridRevealRadius}}">
+                <input type="number" name="flags.world-explorer.gridRevealRadius" value="{{gridRevealRadius}}">
             </div>
             <p class="hint">{{localize "WorldExplorer.SceneSettings.GridReveal.Hint"}}</p>
         </div>


### PR DESCRIPTION
We are getting close to actually implementing partial tiles. This should be the last PR with changes/fixes to the module as it is right now, before adding partial tiles support.

This PR:
* Fixes the issue from the previous PR, where `detectClose` throws an error at load.
* Creates new processes `refreshColors` for setting the tint (color) of the layer. And `updateSettings` for updating settings of the layer to avoid duplicate code.
* Merges the hidden tiles and image layer into one to reduce overhead.
* Sets the alpha (opacity) on the mask instead of on the whole layer.
* Set the mask to only cover the `sceneRect`, as drawing outside of that is useless.
* Renames the mask graphic variable from `graphic` to `hiddenMask` for clarity.
* Set the color in the constructor, and the alpha in the update, to respect the `DEFAULT_SETTINGS`.