### PR TITLE
Change throttle to debounce for help improve Hex update reliability

### DIFF
--- a/module/scene-updater.mjs
+++ b/module/scene-updater.mjs
@@ -66,7 +66,7 @@ export class SceneUpdater {
         }
     }
 
-    #performUpdates = foundry.utils.throttle(async () => {
+    #performUpdates = foundry.utils.debounce(async () => {
         if (this.updating) return;
 
         const updates = {};


### PR DESCRIPTION
Hello @CarlosFdez 

I noticed that sometimes I would experience this lag where the the current Hex that a token was supposed to reveal would not be revealed until I moved the token into another unrevealed hex. Sometimes not even being revealed until I tried to reveal 3 or more hexes, then a bunch of the hexes would reveal all at once.

Anyway I dug into the code a little bit and noticed in the `SceneUpdater` class script that you were using throttle to wrap the async function the sends the updates to the Foundry Scene. I've found in my experience that throttle can sometimes have issues depending on what it's being used for and decided to switch it to debounce which I've found has better results and consistency.

My testing is by no means extensive, but take a look and see if it helps. If the same issue  pops up again I'm willing to take a look at this whole function to try and clean it up some more.

Thanks for making this Module, it's perfect for what a lot of us likely going to need for all of the new Hex Crawl content that's being released these days.


